### PR TITLE
Implement #[no_std] support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ authors = ["Jameson Ernst <jameson@jpernst.com>"]
 description = "A macro to generate self-borrowing structs, plus premade types for convenience."
 repository = "https://github.com/jpernst/rental"
 documentation = "https://docs.rs/rental"
+
+[features]
+default = ["std"]
+std = []


### PR DESCRIPTION
This doesn't change anything for most users, since it's opt-in, using `rental = { default-features = false }` in Cargo.toml.

PS: cool library
PPS: maybe rustfmt it?