### PR TITLE
Refactor FixedDeref into seperate crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,7 @@ documentation = "https://docs.rs/rental"
 
 [features]
 default = ["std"]
-std = []
+std = ["stable_deref_trait/std"]
+
+[dependencies]
+stable_deref_trait = { version = "1.0.0", default-features = false}


### PR DESCRIPTION
Sorry about the extra noisy diffs from the whitespace. My editor is set up to automatically strip trailing whitespace, but I can try to do a PR without those changes if it's a big issue.