### PR TITLE
Update proc-macro2, quote, and syn to v1

### DIFF
--- a/rental-impl/Cargo.toml
+++ b/rental-impl/Cargo.toml
@@ -12,6 +12,6 @@ homepage = "https://www.jpernst.com"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "0.4.18"
-quote = "0.6.8"
-syn = { version = "0.15.1", features = ["full", "fold", "visit", "extra-traits"] }
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", features = ["full", "fold", "visit", "extra-traits"] }

--- a/rental-impl/src/lib.rs
+++ b/rental-impl/src/lib.rs
@@ -21,13 +21,13 @@ fn _extract_input(derive_input: &str) -> &str {
 	let mut input = derive_input;
 
 	for expected in &["#[allow(unused)]", "enum", "ProceduralMasqueradeDummyType", "{", "Input", "=", "(0,", "stringify!", "("] {
-		input = input.trim_left();
+		input = input.trim_start();
 		assert!(input.starts_with(expected), "expected prefix {:?} not found in {:?}", expected, derive_input);
 		input = &input[expected.len()..];
 	}
 
 	for expected in [")", ").0,", "}"].iter().rev() {
-		input = input.trim_right();
+		input = input.trim_end();
 		assert!(input.ends_with(expected), "expected suffix {:?} not found in {:?}", expected, derive_input);
 		let end = input.len() - expected.len();
 		input = &input[..end];


### PR DESCRIPTION
In my quest to eliminate all duplicate dependencies in my projects, I found that `rental` still depended on an older version of `syn` and friends. I have attempted to update everything with their `syn` v1 equivalent. I have run all tests and they pass, and I believe no behavior should have changed from before.